### PR TITLE
Enable handling of Android intents including extra array

### DIFF
--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_webview/InAppWebViewChromeClient.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/in_app_webview/InAppWebViewChromeClient.java
@@ -611,7 +611,7 @@ public class InAppWebViewChromeClient extends WebChromeClient implements PluginR
       }
     }
 
-    URLRequest request = new URLRequest(url, "GET", null, null);
+    URLRequest request = new URLRequest(url, null, "GET", null, null);
     CreateWindowAction createWindowAction = new CreateWindowAction(
             request,
             true,

--- a/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/types/URLRequest.java
+++ b/android/src/main/java/com/pichillilorenzo/flutter_inappwebview/types/URLRequest.java
@@ -10,14 +10,17 @@ public class URLRequest {
   @Nullable
   private String url;
   @Nullable
+  private String intentData;
+  @Nullable
   private String method;
   @Nullable
   private byte[] body;
   @Nullable
   private Map<String, String> headers;
 
-  public URLRequest(@Nullable String url, @Nullable String method, @Nullable byte[] body, @Nullable Map<String, String> headers) {
+  public URLRequest(@Nullable String url, @Nullable String intentData, @Nullable String method, @Nullable byte[] body, @Nullable Map<String, String> headers) {
     this.url = url;
+    this.intentData = intentData;
     this.method = method;
     this.body = body;
     this.headers = headers;
@@ -32,15 +35,20 @@ public class URLRequest {
     if (url == null) {
       url = "about:blank";
     }
+    String intentData = (String) map.get("intentData");
     String method = (String) map.get("method");
     byte[] body = (byte[]) map.get("body");
     Map<String, String> headers = (Map<String, String>) map.get("headers");
-    return new URLRequest(url, method, body, headers);
+    return new URLRequest(url, intentData, method, body, headers);
   }
 
   public Map<String, Object> toMap() {
+    if (intentData != null) {
+      url = "about:blank";
+    }
     Map<String, Object> urlRequestMap = new HashMap<>();
     urlRequestMap.put("url", url);
+    urlRequestMap.put("intentData", intentData);
     urlRequestMap.put("method", method);
     urlRequestMap.put("body", body);
     return urlRequestMap;
@@ -53,6 +61,15 @@ public class URLRequest {
 
   public void setUrl(@Nullable String url) {
     this.url = url;
+  }
+
+  @Nullable
+  public String getIntentData() {
+    return intentData;
+  }
+
+  public void setIntentData(@Nullable String intentData) {
+    this.intentData = intentData;
   }
 
   @Nullable
@@ -90,6 +107,7 @@ public class URLRequest {
     URLRequest that = (URLRequest) o;
 
     if (url != null ? !url.equals(that.url) : that.url != null) return false;
+    if (intentData != null ? !intentData.equals(that.intentData) : that.intentData != null) return false;
     if (method != null ? !method.equals(that.method) : that.method != null) return false;
     if (!Arrays.equals(body, that.body)) return false;
     return headers != null ? headers.equals(that.headers) : that.headers == null;
@@ -98,6 +116,7 @@ public class URLRequest {
   @Override
   public int hashCode() {
     int result = url != null ? url.hashCode() : 0;
+    result = 31 * result + (intentData != null ? intentData.hashCode() : 0);
     result = 31 * result + (method != null ? method.hashCode() : 0);
     result = 31 * result + Arrays.hashCode(body);
     result = 31 * result + (headers != null ? headers.hashCode() : 0);
@@ -108,6 +127,7 @@ public class URLRequest {
   public String toString() {
     return "URLRequest{" +
             "url='" + url + '\'' +
+            ", intentData='" + intentData + '\'' +
             ", method='" + method + '\'' +
             ", body=" + Arrays.toString(body) +
             ", headers=" + headers +


### PR DESCRIPTION
Android intents for chrome can contain extras as an array. Androind Intent.parseUri is able to properly interpret this format and return a Uri. Dart Uri.parse is unable to parse this format correctly and throws an exception.

If we encounter an intent, attempt to parse it and if successful return the raw intent string to dart for handling.

Related SO question
https://stackoverflow.com/questions/73143957/dart-uri-parse-fails-on-intent-with-data